### PR TITLE
WIP: Alterando esquema de salvar imagem de perfil

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
Substituir a forma de salvar atual, que é no S3, e passar a salvar o blob da imagem no MongoDB.

Talvez fazer o mesmo para as outras imagens também (produtos, categorias etc.)